### PR TITLE
fix door animation flicker in Safari

### DIFF
--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -81,6 +81,10 @@ html {
 }
 
 @layer utilities {
+  .door {
+    /* Fix for flickering door animation in Safari */
+    perspective: 2000px;
+  }
   .door-open {
     transform: perspective(2000px) rotateY(10deg);
   }

--- a/web/src/ui/Door.tsx
+++ b/web/src/ui/Door.tsx
@@ -38,7 +38,7 @@ export const Door: React.FC<IProps> = ({
   return (
     <div
       className={classNames(
-        "bg-primary-900 group h-128 lg:rounded-t-lg",
+        "bg-primary-900 group h-128 lg:rounded-t-lg door",
         {
           "transition-transform": animate,
           "z-50": zIndex === "front",


### PR DESCRIPTION
Fix #39 

Couldn't reproduce in Safari desktop `Version 16.1 (18614.2.9.1.12)`, but was able to do it in mobile version. Not sure if the animation is needed on mobile version though.

Before fix: 
https://user-images.githubusercontent.com/6494049/224832128-1c8738af-91c4-44a0-84c0-e68480ede3d8.mp4

After fix:
https://user-images.githubusercontent.com/6494049/224832196-c79ef7d1-f195-440b-902e-98fc467888c3.mp4

