### PR TITLE
Add support for multiple course holders

### DIFF
--- a/studio/app/schemas/documents/course.ts
+++ b/studio/app/schemas/documents/course.ts
@@ -1,5 +1,5 @@
-import { Author } from "../schemaTypes";
 import { PortableText, SanitySlug } from "../../../../types/sanityTypes";
+import { Author } from "../schemaTypes";
 
 export type Course = {
   _id: string;
@@ -10,7 +10,7 @@ export type Course = {
   endTime: string;
   price: string;
   location: string;
-  courseHolder: Author;
+  courseHolders: Author[];
   signUpLink: string;
   slug: SanitySlug;
   body: PortableText;
@@ -65,10 +65,10 @@ export default {
       type: "string",
     },
     {
-      name: "courseHolder",
-      title: "Kursholder",
-      type: "reference",
-      to: [{ type: "author" }],
+      name: "courseHolders",
+      title: "Kursholdere",
+      type: "array",
+      of: [{ type: "reference", to: [{ type: "author" }] }],
     },
     {
       name: "signUpLink",

--- a/studio/migrations/course-courseHolderToArray.js
+++ b/studio/migrations/course-courseHolderToArray.js
@@ -1,0 +1,81 @@
+import { createClient } from "@sanity/client";
+
+const token = process.env.SANITY_TOKEN;
+const projectId = process.env.SANITY_PROJECT_ID;
+const dataset = process.env.SANITY_DATASET;
+const apiVersion = "2023-03-01";
+
+const client = createClient({
+  apiVersion,
+  projectId,
+  dataset,
+  token,
+});
+
+// Run this script from within your project folder in your terminal with: `sanity exec --with-user-token migrations/course-courseHolderToArray.js`
+//
+// This will migrate documents in batches of 100 and continue patching until no more documents are
+// returned from the query.
+//
+// This script can safely be run, even if documents are being concurrently modified by others.
+// If a document gets modified in the time between fetch => submit patch, this script will fail,
+// but can safely be re-run multiple times until it eventually runs out of documents to migrate.
+
+// A few things to note:
+// - This script will exit if any of the mutations fail due to a revision mismatch (which means the
+//   document was edited between fetch => update)
+// - The query must eventually return an empty set, or else this script will continue indefinitely
+
+// Fetching documents that matches the precondition for the migration.
+// NOTE: This query should eventually return an empty set of documents to mark the migration
+// as complete
+const fetchDocuments = () =>
+  client.fetch(
+    `*[_type == 'course' && defined(courseHolder)][0...100] {_id, _rev, courseHolder}`
+  );
+
+const buildPatches = (docs) =>
+  docs.map((doc) => ({
+    id: doc._id,
+    patch: {
+      set: {
+        courseHolders: [{ _type: "reference", _ref: doc.courseHolder._ref }],
+      },
+      // removes the old field
+      unset: ["courseHolder"],
+      // this will cause the transaction to fail if the documents has been
+      // modified since it was fetched.
+      ifRevisionID: doc._rev,
+    },
+  }));
+
+const createTransaction = (patches) =>
+  patches.reduce(
+    (tx, patch) => tx.patch(patch.id, patch.patch),
+    client.transaction()
+  );
+
+const commitTransaction = (tx) => tx.commit();
+
+const migrateNextBatch = async () => {
+  const documents = await fetchDocuments();
+  const patches = buildPatches(documents);
+  if (patches.length === 0) {
+    console.log("No more documents to migrate!");
+    return null;
+  }
+  console.log(
+    `Migrating batch:\n %s`,
+    patches
+      .map((patch) => `${patch.id} => ${JSON.stringify(patch.patch)}`)
+      .join("\n")
+  );
+  const transaction = createTransaction(patches);
+  await commitTransaction(transaction);
+  return migrateNextBatch();
+};
+
+migrateNextBatch().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/web/src/features/course/CourseInfo.tsx
+++ b/web/src/features/course/CourseInfo.tsx
@@ -3,7 +3,7 @@ import { Body1 } from "@Ui/Typography";
 import * as React from "react";
 
 export const CourseInfo: React.FC<{ course: Course }> = ({
-  course: { date, startTime, endTime, location, price, courseHolder },
+  course: { date, startTime, endTime, location, price, courseHolders },
 }) => {
   const formattedDate =
     date && new Date(date).toLocaleDateString("no-nb", { dateStyle: "long" });
@@ -15,7 +15,7 @@ export const CourseInfo: React.FC<{ course: Course }> = ({
       {startTime && <Body1>{`🕐 Tid: ${formattedTime}`}</Body1>}
       {location && <Body1>{`📍 Sted: ${location}`}</Body1>}
       {price && <Body1>{`💰 Pris: ${price}`}</Body1>}
-      {courseHolder && <Body1>{`👨‍🏫 Kursholder: ${courseHolder.name}`}</Body1>}
+      {courseHolders && courseHolders.length > 0 && <Body1>{`👨‍🏫 Kursholder: ${courseHolders.join(", ")}`}</Body1>}
     </div>
   );
 };

--- a/web/src/lib/globalFragments.ts
+++ b/web/src/lib/globalFragments.ts
@@ -34,7 +34,7 @@ export const query = graphql`
     startTime
     endTime
     price
-    courseHolder {
+    courseHolders {
       name
     }
   }

--- a/web/src/pages/kurs.tsx
+++ b/web/src/pages/kurs.tsx
@@ -1,14 +1,9 @@
-import { PageHeader, PagePageHeader } from "@Components/PageHeader";
+import { PageHeader } from "@Components/PageHeader";
 import { Seo } from "@Components/Seo";
-import { AdThumbnail } from "@Features/ad/components/AdThumbnail";
-import { FilterRow } from "@Features/ad/components/FilterRow";
-import { ALL_STRING, useJobPageAds } from "@Features/ad/lib/useAds";
-import { CourseEmptyState } from "@Features/course/CourseEmptyState";
-import { CoursePageHeader } from "@Features/course/CoursePageHeader";
 import { CourseThumbnail } from "@Features/course/CourseThumbnail";
 import { VectorIllustrations } from "@Images/VectorIllustrations";
 import { cleanGraphqlArray } from "@Lib/helpers";
-import { Ad, Course, GraphqlEdges, PageType } from "@Types";
+import { Course, GraphqlEdges, PageType } from "@Types";
 import { PageWrapper } from "@Ui/Layout";
 import { BlockContent } from "@Ui/Typography";
 import { graphql, PageProps } from "gatsby";


### PR DESCRIPTION
Fix #44 

Vi må kjøre et migration script på dataen før et nytt bygg kjøres ut, se filen `studio/migrations/course-courseHolderToArray.js` for detaljer.

Jeg tenkte først at dette burde deles opp i 3 deler, men det er kanskje ikke nødvendig pga sidene er statisk bygget, anyways her var original beskrivelse av hvordan det skulle gjøres hvis vi må endre på det: 
1. Lag et nytt felt kalt `courseHolders`, og så kjøre migration script for å legge `courseHolder` inn i arrayet
2. Ta i bruk `courseHolders` i koden
3. Slett `courseHolder` feltet

**OBS: Jeg har ikke testet migreringsscriptet da jeg ikke har tilgang til å kjøre det mot Sanity**
Scriptet er basert på https://www.sanity.io/docs/migrating-data